### PR TITLE
Shader management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
  "context",
  "framegraph",
  "glam",
+ "glob",
  "gpu-allocator",
  "imgui",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "memoffset 0.6.5",
  "num",
  "passes",
+ "raw-window-handle 0.6.0",
  "tobj",
  "winapi",
  "winit",
@@ -1289,6 +1290,12 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "raw-window-metal"

--- a/context/src/api_types/surface.rs
+++ b/context/src/api_types/surface.rs
@@ -2,9 +2,6 @@ use std::os::raw::c_void;
 use ash::extensions::khr::Win32Surface;
 use ash::vk;
 
-extern crate winapi;
-use winapi::um::libloaderapi::GetModuleHandleW;
-use winit::platform::windows::WindowExtWindows;
 use crate::api_types::device::PhysicalDeviceWrapper;
 
 pub struct SurfaceWrapper {
@@ -32,25 +29,6 @@ impl SurfaceCapabilities {
     }
 }
 
-#[cfg(target_os = "windows")]
-unsafe fn create_window_surface(
-    entry: &ash::Entry,
-    instance: &ash::Instance,
-    window: &winit::window::Window
-) -> Result<vk::SurfaceKHR, vk::Result> {
-    let hwnd = window.hwnd() as vk::HWND;
-    let hinstance = GetModuleHandleW(std::ptr::null());
-    let create_info = vk::Win32SurfaceCreateInfoKHR {
-        s_type: vk::StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
-        p_next: std::ptr::null(),
-        flags: Default::default(),
-        hinstance: hinstance as *const c_void,
-        hwnd: hwnd as *const c_void
-    };
-    let surface_loader = Win32Surface::new(entry, instance);
-    surface_loader.create_win32_surface(&create_info, None)
-}
-
 impl SurfaceWrapper {
     pub fn new(
         entry: &ash::Entry,
@@ -58,7 +36,7 @@ impl SurfaceWrapper {
         window: &winit::window::Window
     ) -> SurfaceWrapper {
         let surface = unsafe {
-            create_window_surface(entry, instance, window)
+            ash_window::create_surface(entry, instance, &window, None)
                 .expect("Failed to create window surface")
         };
         let surface_loader = ash::extensions::khr::Surface::new(entry, instance);

--- a/context/src/api_types/surface.rs
+++ b/context/src/api_types/surface.rs
@@ -56,26 +56,25 @@ impl SurfaceWrapper {
     }
 
     pub fn get_surface_capabilities(&self,
-        physical_device: &PhysicalDeviceWrapper,
-        surface: &SurfaceWrapper
+        physical_device: &PhysicalDeviceWrapper
     ) -> SurfaceCapabilities {
         unsafe {
-            let capabilities = surface.get_loader()
+            let capabilities = self.get_loader()
                 .get_physical_device_surface_capabilities(
                     physical_device.get(),
-                    surface.get_surface())
+                    self.get_surface())
                 .expect("Failed to query device for surface capabilities.");
 
-            let formats = surface.get_loader()
+            let formats = self.get_loader()
                 .get_physical_device_surface_formats(
                     physical_device.get(),
-                    surface.get_surface())
+                    self.get_surface())
                 .expect("Failed to query for surface formats.");
 
-            let present_modes = surface.get_loader()
+            let present_modes = self.get_loader()
                 .get_physical_device_surface_present_modes(
                     physical_device.get(),
-                    surface.get_surface() )
+                    self.get_surface() )
                 .expect("Failed to query surface for present modes.");
 
             SurfaceCapabilities::new(capabilities, formats, present_modes)

--- a/framegraph-examples/Cargo.toml
+++ b/framegraph-examples/Cargo.toml
@@ -20,6 +20,7 @@ glam                = "0.21.2"
 gpu-allocator       = "^0.17"
 imgui               = "^0.11.0"
 imgui-winit-support = "0.11.0"
+raw-window-handle   = "0.6.0"
 
 [build-dependencies]
 glob        = "0.3.0"

--- a/framegraph-examples/src/main.rs
+++ b/framegraph-examples/src/main.rs
@@ -62,7 +62,8 @@ impl WindowedVulkanApp {
         let render_context = {
             let c_title = CString::new(title).unwrap();
             let application_info = vk::ApplicationInfo::builder()
-                .application_name(&c_title);
+                .application_name(&c_title)
+                .api_version(vk::API_VERSION_1_2);
 
             VulkanRenderContext::new(
                 &application_info,

--- a/framegraph-examples/src/ubo_example.rs
+++ b/framegraph-examples/src/ubo_example.rs
@@ -51,8 +51,9 @@ impl Example for UboExample {
             RasterizationType::Standard,
             DepthStencilType::Disable,
             BlendType::None,
-            "ubo-vert.spv",
-            "ubo-frag.spv");
+            "ubo",
+            self.vert_shader.clone(),
+            self.frag_shader.clone());
         
         let ubo_binding = ResourceBinding {
             resource: self.uniform_buffer.clone(),

--- a/framegraph/src/pipeline.rs
+++ b/framegraph/src/pipeline.rs
@@ -8,7 +8,7 @@ use ash::vk;
 use context::api_types::device::{DevicePipeline, DeviceWrapper};
 use context::render_context::RenderContext;
 
-use crate::shader::ShaderManager;
+use crate::shader::{Shader, ShaderManager};
 
 extern crate context;
 use context::vulkan_render_context::VulkanRenderContext;
@@ -41,8 +41,9 @@ pub struct PipelineDescription
     rasterization: RasterizationType,
     depth_stencil: DepthStencilType,
     blend: BlendType,
-    vertex_name: String,
-    fragment_name: String
+    name: String,
+    vertex_shader: Rc<RefCell<Shader>>,
+    fragment_shader: Rc<RefCell<Shader>>
 }
 
 impl Hash for PipelineDescription
@@ -50,8 +51,7 @@ impl Hash for PipelineDescription
     fn hash<H: Hasher>(&self, state: &mut H) {
         // TODO: this is an inadequate hash
         // will need to actually use some pipeline state for a better hash
-        self.vertex_name.hash(state);
-        self.fragment_name.hash(state);
+        self.name.hash(state);
     }
 }
 
@@ -63,8 +63,9 @@ impl PipelineDescription
         rasterization: RasterizationType,
         depth_stencil: DepthStencilType,
         blend: BlendType,
-        vertex_name: &str,
-        fragment_name: &str) -> Self
+        name: &str,
+        vertex_shader: Rc<RefCell<Shader>>,
+        fragment_shader: Rc<RefCell<Shader>>) -> Self
     {
         PipelineDescription {
             vertex_input,
@@ -72,12 +73,13 @@ impl PipelineDescription
             rasterization,
             depth_stencil,
             blend,
-            vertex_name: vertex_name.to_string(),
-            fragment_name: fragment_name.to_string()
+            name: name.to_string(),
+            vertex_shader,
+            fragment_shader
         }
     }
 
-    pub fn get_name(&self) -> &str { &self.vertex_name }
+    pub fn get_name(&self) -> &str { &self.name }
 }
 
 
@@ -410,18 +412,11 @@ impl VulkanPipelineManager {
         match pipeline_val {
             Some(pipeline) => { pipeline.clone() },
             None => {
-                let mut vertex_shader_module = self.shader_manager.load_shader(
-                    render_context.get_device(),
-                    &pipeline_description.vertex_name);
-                let mut frag_shader_module = self.shader_manager.load_shader(
-                    render_context.get_device(),
-                    &pipeline_description.fragment_name);
-
                 // Need to reconcile descriptor bindings between vertex and fragment stages
                 //  i.e. - Could have duplicate bindings for descriptors used in both stages, or
                 //  bindings only used in a single stage but are part of a larger descriptor set
                 let mut full_bindings: HashMap<u32, Vec<vk::DescriptorSetLayoutBinding>> = HashMap::new();
-                for (set, bindings) in &mut vertex_shader_module.borrow_mut().descriptor_bindings {
+                for (set, bindings) in &pipeline_description.vertex_shader.borrow().descriptor_bindings {
                     let set_bindings = full_bindings.entry(*set).or_insert(Vec::new());
                     // set_bindings.copy_from_slice(&bindings);
                     set_bindings.extend(bindings.iter());
@@ -429,7 +424,7 @@ impl VulkanPipelineManager {
                         binding.stage_flags = vk::ShaderStageFlags::VERTEX;
                     }
                 }
-                for (set, bindings) in &mut frag_shader_module.borrow_mut().descriptor_bindings {
+                for (set, bindings) in &pipeline_description.fragment_shader.borrow().descriptor_bindings {
                     let set_bindings = full_bindings.entry(*set).or_insert(Vec::new());
                     for binding in bindings {
                         let duplicate = set_bindings.iter_mut().find(|x| {
@@ -440,8 +435,9 @@ impl VulkanPipelineManager {
                                dupe_binding.stage_flags |= vk::ShaderStageFlags::FRAGMENT;
                             },
                             None => {
-                                binding.stage_flags = vk::ShaderStageFlags::FRAGMENT;
-                                set_bindings.push(binding.clone());
+                                let mut new_binding = binding.clone();
+                                new_binding.stage_flags = vk::ShaderStageFlags::FRAGMENT;
+                                set_bindings.push(new_binding);
                             }
                         }
                     }
@@ -498,7 +494,7 @@ impl VulkanPipelineManager {
                         s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
                         p_next: std::ptr::null(),
                         flags: vk::PipelineShaderStageCreateFlags::empty(),
-                        module: vertex_shader_module.borrow().shader.shader_module.clone(),
+                        module: pipeline_description.vertex_shader.borrow().shader.shader_module.clone(),
                         p_name: main_name.as_ptr(),
                         p_specialization_info: std::ptr::null(),
                         stage: vk::ShaderStageFlags::VERTEX,
@@ -508,7 +504,7 @@ impl VulkanPipelineManager {
                         s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
                         p_next: std::ptr::null(),
                         flags: vk::PipelineShaderStageCreateFlags::empty(),
-                        module: frag_shader_module.borrow().shader.shader_module.clone(),
+                        module: pipeline_description.fragment_shader.borrow().shader.shader_module.clone(),
                         p_name: main_name.as_ptr(),
                         p_specialization_info: std::ptr::null(),
                         stage: vk::ShaderStageFlags::FRAGMENT,

--- a/passes/Cargo.toml
+++ b/passes/Cargo.toml
@@ -12,3 +12,6 @@ imgui           = "0.11.0"
 gpu-allocator   = "^0.17"
 context         =  {path="../context"}
 framegraph      = {path="../framegraph"}
+
+[build-dependencies]
+glob            = "0.3.1"

--- a/passes/build.rs
+++ b/passes/build.rs
@@ -1,4 +1,65 @@
-// This needs to exist for OUT_DIR to be provided to the compiler
-fn main() {
+extern crate glob;
 
+use std::process::Command;
+use std::env;
+
+use glob::{glob, Paths};
+
+fn compile_shaders(paths: Paths, out_dir: &str) {
+    for entry in paths {
+        println!("Found entry");
+        match entry {
+            Ok(shader_source) => {
+                let shader_path = shader_source.as_path();
+                let shader_name = shader_path.file_stem()
+                    .expect("Unknown shader name")
+                    .to_str().unwrap();
+                let shader_ext = shader_path.extension()
+                    .expect("Couldn't determine shader extension")
+                    .to_str().unwrap();
+                // Command::new("glslc").args(&[shader_path.to_str().unwrap(), "--target-env=vulkan1.1", "-o"])
+                Command::new("glslangValidator").args(&[shader_path.to_str().unwrap(), "--target-env", "vulkan1.1", "-o"])
+                    .arg(&format!("{}/shaders/{}-{}.spv", out_dir, shader_name, shader_ext))
+                    .status()
+                    .expect("Error compiling shader");
+            },
+            Err(e) => {
+                println!("Failed to compile shaders");
+                panic!("{}", e);
+            }
+        }
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=shaders");
+    println!("cargo:rerun-if-changed='../passes/shaders'");
+    println!("Compiling shaders");
+    // let bin_dir = env::var("CARGO_BIN_EXE_".to_string() + &env::var("CARGO_BIN_NAME").expect("Couldn't get bin name")).expect(("Couldn't get bin directory"));
+    // let out_dir = env::var("CARGO_BIN_EXE_".to_string() + &env::var("CARGO_BIN_NAME").expect("Couldn't get bin name")).expect(("Couldn't get bin directory"));
+    // let out_dir = "target/".to_owned() + &env::var("PROFILE").expect("Couldn't get profile");
+    let out_dir = env::var("OUT_DIR").expect("Couldn't get output dir");
+    println!("Shader output directory: {}", out_dir);
+
+    std::fs::create_dir_all(&format!("{}/shaders", out_dir))
+        .expect("Failed to create shader output directory");
+    println!("Placing shaders at {}", &out_dir);
+
+    let vert_shaders = glob("shaders/*.vert").expect("No vert shaders found");
+    let frag_shaders = glob("shaders/*.frag").expect("No frag shaders found");
+    let compute_shaders = glob("shaders/*.comp").expect("No compute shaders found");
+
+    let pass_vert_shaders = glob("../passes/shaders/*.vert")
+        .expect("No pass vert shaders");
+    let pass_frag_shaders = glob("../passes/shaders/*.frag")
+        .expect("No pass frag shaders");
+    let pass_compute_shaders = glob("../passes/shaders/*.comp")
+        .expect("No pass compute shaders");
+
+    compile_shaders(vert_shaders, &out_dir);
+    compile_shaders(frag_shaders, &out_dir);
+    compile_shaders(compute_shaders, &out_dir);
+    compile_shaders(pass_vert_shaders, &out_dir);
+    compile_shaders(pass_frag_shaders, &out_dir);
+    compile_shaders(pass_compute_shaders, &out_dir);
 }

--- a/passes/src/imgui_draw.rs
+++ b/passes/src/imgui_draw.rs
@@ -17,6 +17,8 @@ use framegraph::binding::{BindingInfo, BindingType, BufferBindingInfo, ImageBind
 use framegraph::graphics_pass_node::GraphicsPassNode;
 use framegraph::pass_type::PassType;
 use framegraph::pipeline::{BlendType, DepthStencilType, PipelineDescription, RasterizationType};
+use framegraph::shader;
+use framegraph::shader::Shader;
 
 const IMGUI_VERTEX_BINDING: vk::VertexInputBindingDescription = vk::VertexInputBindingDescription{
     binding: 0,
@@ -56,6 +58,8 @@ pub struct DisplayBuffer {
 }
 
 pub struct ImguiRender {
+    vertex_shader: Rc<RefCell<Shader>>,
+    fragment_shader: Rc<RefCell<Shader>>,
     font_texture: Rc<RefCell<DeviceResource>>
 }
 
@@ -70,6 +74,11 @@ impl ImguiRender {
         device: Rc<RefCell<DeviceWrapper>>,
         render_context: &VulkanRenderContext,
         font_atlas: imgui::FontAtlasTexture) -> ImguiRender {
+
+        let vert_shader = Rc::new(RefCell::new(
+            shader::create_shader_module_from_bytes(device.clone(), "imgui-vert", include_bytes!(concat!(env!("OUT_DIR"), "/shaders/imgui-vert.spv")))));
+        let frag_shader = Rc::new(RefCell::new(
+            shader::create_shader_module_from_bytes(device.clone(), "imgui-frag", include_bytes!(concat!(env!("OUT_DIR"), "/shaders/imgui-frag.spv")))));
 
         let font_buffer_create = BufferCreateInfo::new(
             vk::BufferCreateInfo::builder()
@@ -272,6 +281,8 @@ impl ImguiRender {
         }
 
         ImguiRender {
+            vertex_shader: vert_shader,
+            fragment_shader: frag_shader,
             font_texture: Rc::new(RefCell::new(font_texture)),
         }
     }
@@ -399,8 +410,9 @@ impl ImguiRender {
                 RasterizationType::Standard,
                 DepthStencilType::Disable,
                 BlendType::Transparent,
-                "imgui-vert.spv",
-                "imgui-frag.spv");
+                "imgui",
+                self.vertex_shader.clone(),
+                self.fragment_shader.clone());
 
             let display_binding = ResourceBinding {
                 resource: display_buffer.clone(),


### PR DESCRIPTION
PipelineDescription now owns refcounted Shaders. This moves shader management outside of the framegraph, and it's up to pass owners or external mechanisms to handle shader module lifetimes.